### PR TITLE
Add semicolons, commons so grunt can parse file

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,11 @@ dojo: {
       profile: 'app.profile.js', // Profile for build
       appConfigFile: '', // Optional: Config file for dojox/app
       package: '', // Optional: Location to search package.json (Default: nothing)
-      packages [], // Optional: Array of locations of package.json (Default: nothing)
+      packages: [], // Optional: Array of locations of package.json (Default: nothing)
       require: '', // Optional: Module to require for the build (Default: nothing)
-      requires [], // Optional: Array of modules to require for the build (Default: nothing)
+      requires: [], // Optional: Array of modules to require for the build (Default: nothing)
       cwd: './', // Directory to execute build within
-      dojoConfig: '' // Optional: Location of dojoConfig (Default: null),
+      dojoConfig: '', // Optional: Location of dojoConfig (Default: null),
       // Optional: Base Path to pass at the command line
       // Takes precedence over other basePaths
       // Default: null
@@ -49,11 +49,11 @@ dojo: {
     profile: 'app.profile.js', // Profile for build
     appConfigFile: '', // Optional: Config file for dojox/app
     package: '', // Optional: Location to search package.json (Default: nothing)
-    packages [], // Optional: Array of locations of package.json (Default: nothing)
+    packages: [], // Optional: Array of locations of package.json (Default: nothing)
     require: '', // Optional: Module to require for the build (Default: nothing)
-    requires [], // Optional: Array of modules to require for the build (Default: nothing)
+    requires: [], // Optional: Array of modules to require for the build (Default: nothing)
     cwd: './', // Directory to execute build within
-    dojoConfig: '' // Optional: Location of dojoConfig (Default: null),
+    dojoConfig: '', // Optional: Location of dojoConfig (Default: null),
     // Optional: Base Path to pass at the command line
     // Takes precedence over other basePaths
     // Default: null


### PR DESCRIPTION
Just some changes to the readme. Missing semicolons and commas made json invalid so grunt wouldn't parse. Hope this helps!
