### PR TITLE
Enable passing of optimizations params

### DIFF
--- a/tasks/dojo.js
+++ b/tasks/dojo.js
@@ -176,6 +176,54 @@ module.exports = function(grunt) {
       if(options.action){
        addParam('--action', options.action);
       }
+
+      if (options.layerOptimize != undefined){
+       addParam("--layerOptimize", options.layerOptimize);
+      }
+
+      if (options.cssOptimize){
+       addParam("--cssOptimize", options.cssOptimize);
+      }
+
+      if (options.optimize){
+       addParam("--optimize", options.optimize);
+      }
+
+      if (options.mini){
+       addParam("--mini", options.mini);
+      }
+
+      if (options.stripConsole != undefined){
+       addParam("--stripConsole", options.stripConsole);
+      }
+
+      if (options.selectorEngine){
+       addParam("--selectorEngine", options.selectorEngine);
+      }
+
+      if (options.localeList){
+       addParam("--localeList", options.localeList);
+      }
+
+      if (options.loader){
+       addParam("--loader", options.loader);
+      }
+
+      if (options.internStrings){
+       addParam("--internStrings", options.internStrings);
+      }
+
+      if (options.copyTests){
+       addParam("--copyTests", options.copyTests);
+      }
+
+      if (options.log){
+       addParam("--log", options.log);
+      }
+
+      if (options.xdDojoPath){
+       addParam("--xdDojoPath", options.xdDojoPath);
+      }
     } else {
       grunt.log.error('No dojo specified');
       done(false);


### PR DESCRIPTION
Sometimes you want to configure or disable optimizations. This patch
adds options to do this.

layerOptimize does not default to a falsy value, so we check for
undefined there in order to be able to disable it. optimize and
cssOptimize both default to false.